### PR TITLE
Add the papaparse options to the button/link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ import { CSVDownloader } from 'svelte-csv';
 </CSVDownloader>
 ```
 
-#### Link
+#### Button
 
 ```javascript
 import { CSVDownloader } from 'svelte-csv';
@@ -123,6 +123,33 @@ import { CSVDownloader } from 'svelte-csv';
   Download
 </CSVDownloader>
 ```
+
+**Option**
+
+It is possible to supply options through `options={optionObj}`. For available options, 
+see the [papaparse docs](https://www.papaparse.com/docs#unparse-config-default)
+```javascript
+import { CSVDownloader } from 'svelte-csv';
+
+<CSVDownloader
+  data={[]}
+  options={
+      {
+          quotes: false, //or array of booleans
+          quoteChar: '"',
+          escapeChar: '"',
+          delimiter: ";",
+          header: true,
+          newline: "\r\n",
+          skipEmptyLines: false, //other option is 'greedy', meaning skip delimiters, quotes, and whitespace.
+          columns: null //or array of strings
+      }
+  }
+>
+  Download
+</CSVDownloader>
+```
+
 
 ### 🎀 readString
 

--- a/src/CSVDownloader.d.ts
+++ b/src/CSVDownloader.d.ts
@@ -1,0 +1,1 @@
+export type ComponentType = 'link' | 'button';

--- a/src/CSVDownloader.svelte
+++ b/src/CSVDownloader.svelte
@@ -32,11 +32,11 @@
 </script>
 
 {#if type === 'link'}
-  <span on:click={download(data, filename, bom)} class="link">
+  <span class={$$props.class + " link"} on:click={download(data, filename, bom)}>
     <slot />
   </span>
 {:else}
-  <button on:click={download(data, filename, bom)}>
+  <button class={$$props.class} on:click={download(data, filename, bom)}>
     <slot />
   </button>
 {/if}

--- a/src/CSVDownloader.svelte
+++ b/src/CSVDownloader.svelte
@@ -4,11 +4,13 @@
   export let filename = 'filename';
   export let type = 'link';
   export let bom = 2;
+  export let options = undefined;
+
   function download(data, filename, bom) {
     const bomCode = bom ? '\ufeff' : '';
     let csvContent = null;
     if (typeof data === 'object') {
-      csvContent = PapaParse.unparse(data);
+      csvContent = PapaParse.unparse(data, options);
     } else {
       csvContent = data;
     }

--- a/src/CSVDownloader.svelte
+++ b/src/CSVDownloader.svelte
@@ -1,10 +1,12 @@
-<script>
+<script lang="ts">
   import PapaParse from 'papaparse';
+  import type { ComponentType } from './CSVDownloader';
+
   export let data;
-  export let filename = 'filename';
-  export let type = 'link';
-  export let bom = 2;
-  export let options = undefined;
+  export let filename: string = 'filename';
+  export let type: ComponentType = 'link';
+  export let bom: number = 2;
+  export let options: PapaParse.UnparseConfig | undefined = undefined;
 
   function download(data, filename, bom) {
     const bomCode = bom ? '\ufeff' : '';
@@ -32,11 +34,11 @@
 </script>
 
 {#if type === 'link'}
-  <span class={$$props.class + " link"} on:click={download(data, filename, bom)}>
+  <span class={$$props.class + " link"} on:click={() => download(data, filename, bom)}>
     <slot />
   </span>
 {:else}
-  <button class={$$props.class} on:click={download(data, filename, bom)}>
+  <button class={$$props.class} on:click={() => download(data, filename, bom)}>
     <slot />
   </button>
 {/if}


### PR DESCRIPTION
It would be nice to add the papaparse config options to the link itself. It is currently possible to first parse the json and then feed it to the link, but it would be so much easier to immediatly add it to the svelte element. 